### PR TITLE
chore: align URLs + base path with renamed repo (toolglass) + add CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
+      runtime:
+        dependency-type: production
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-3178c6.svg)](https://www.typescriptlang.org)
 [![Vite](https://img.shields.io/badge/Vite-5-646cff.svg)](https://vitejs.dev)
 
-🔗 **Live:** https://ajithakdev.github.io/password-generator-v1/
+🔗 **Live:** https://ajithakdev.github.io/toolglass/
 
 </div>
 
@@ -50,7 +50,7 @@ Toolglass bundles nine of the utilities you reach for every day into a single gl
 ## 🚀 Quick start
 
 ```bash
-git clone https://github.com/ajithakdev/password-generator-v1.git toolglass
+git clone https://github.com/ajithakdev/toolglass.git
 cd toolglass
 npm install
 npm run dev

--- a/package.json
+++ b/package.json
@@ -6,7 +6,14 @@
   "description": "Toolglass — frosted developer utilities. 9 beautiful, lightning-fast, 100% client-side tools (password, JWT, UUID, ObjectId, NanoID, hash, base64, timestamp, JSON).",
   "license": "MIT",
   "author": "ajithakdev",
-  "homepage": "https://ajithakdev.github.io/password-generator-v1",
+  "homepage": "https://ajithakdev.github.io/toolglass",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ajithakdev/toolglass.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ajithakdev/toolglass/issues"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ function Shell({ children }: { children: React.ReactNode }) {
           <span style={{ fontWeight: 700, letterSpacing: '-0.01em' }}>Toolglass</span>
         </Link>
         <a
-          href="https://github.com/ajithakdev/password-generator-v1"
+          href="https://github.com/ajithakdev/toolglass"
           target="_blank"
           rel="noreferrer"
           style={{ fontSize: 13, color: 'var(--ink-soft)', fontWeight: 500 }}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  base: '/password-generator-v1/',
+  base: '/toolglass/',
   plugins: [react()],
   build: { target: 'es2022', sourcemap: false },
 });


### PR DESCRIPTION
## Why

Repo was renamed `password_generator_v1` → **toolglass**. This PR aligns every code/url reference to the new name and adds a proper CI + auto-deploy pipeline.

## Changes

### 🔗 URL + base path realignment
- `vite.config.ts` — `base: '/password-generator-v1/'` → **`'/toolglass/'`** (GH Pages serves from the repo path; this is required or the SPA assets 404).
- `package.json` — `homepage` updated; added `repository` and `bugs` fields pointing to the new repo.
- `README.md` — live URL + clone command point to `toolglass`.
- `src/App.tsx` — nav GitHub link updated.

### 🤖 CI / CD / Bots
- `.github/workflows/ci.yml` — lint + build on PR and main push, Node 20, npm cache.
- `.github/workflows/deploy.yml` — official GitHub Pages action pipeline (configure-pages → upload-pages-artifact → deploy-pages). Concurrency group ensures only the latest commit ships. Replaces the manual `npm run deploy` flow.
- `.github/dependabot.yml` — weekly npm bumps (grouped dev / runtime) + monthly actions updates.

## After merge — manual steps

1. **Repo → Settings → Pages → Source: `GitHub Actions`** (switch off the `gh-pages` branch source; the workflow now publishes directly).
2. First push to main after the switch will auto-deploy to **https://ajithakdev.github.io/toolglass/**.
3. (Optional) Delete the now-unused `gh-pages` branch once the Actions deploy succeeds.

## Verification

- `npx tsc -b && npx vite build` — passes, build 3s, bundle unchanged (~94 KB gz main).