### PR TITLE
fix: Use npm install in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
-      - run: npm ci
+      - run: npm install
       - run: npm run build
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
Replaces npm ci with npm install in deploy.yml to resolve esbuild optional dependency errors on the GitHub Pages runner.