### PR TITLE
feat(resilience): add glassmorphic ErrorBoundary and custom 404 page (#56, #65)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import { ToastProvider } from './components/ui/Toast';
 import { useTheme } from './hooks/useTheme';
 import { useToolStats } from './hooks/useToolStats';
 import { Search, Download, ExternalLink, Sparkles } from 'lucide-react';
+import { ErrorBoundary } from './components/ErrorBoundary';
+import { NotFound } from './pages/NotFound';
 
 function InstallPwaButton() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -209,11 +211,13 @@ export default function App() {
   return (
     <ToastProvider>
       <Shell onOpenPalette={() => setPaletteOpen(true)}>
-        <Routes>
-          <Route path="/" element={<Landing />} />
-          <Route path="/tools/:slug" element={<ToolPage />} />
-          <Route path="*" element={<Landing />} />
-        </Routes>
+        <ErrorBoundary>
+          <Routes>
+            <Route path="/" element={<Landing />} />
+            <Route path="/tools/:slug" element={<ToolPage />} />
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </ErrorBoundary>
       </Shell>
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
     </ToastProvider>

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { MemoryRouter } from 'react-router-dom';
+import { ErrorBoundary } from './ErrorBoundary';
+
+// Configure act environment for React 19
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function ProblemChild({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error('Simulated tool rendering crash');
+  }
+  return <div data-testid="child-content">Normal Tool Content</div>;
+}
+
+describe('ErrorBoundary Component', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('renders children normally when no error occurs', () => {
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <ErrorBoundary toolTitle="Timestamp">
+            <ProblemChild shouldThrow={false} />
+          </ErrorBoundary>
+        </MemoryRouter>
+      );
+    });
+
+    expect(container.textContent).toContain('Normal Tool Content');
+    expect(container.querySelector('[data-testid="child-content"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="error-boundary-card"]')).toBeNull();
+  });
+
+  it('catches render errors and displays the glassmorphic error fallback UI', () => {
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <ErrorBoundary toolTitle="Timestamp Converter">
+            <ProblemChild shouldThrow={true} />
+          </ErrorBoundary>
+        </MemoryRouter>
+      );
+    });
+
+    expect(container.querySelector('[data-testid="error-boundary-card"]')).not.toBeNull();
+    expect(container.textContent).toContain('Timestamp Converter encountered an error');
+    expect(container.textContent).toContain('Simulated tool rendering crash');
+    expect(container.textContent).toContain('100% Client-Side Privacy');
+  });
+
+  it('renders custom fallback if provided', () => {
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <ErrorBoundary
+            fallback={(error, reset) => (
+              <div>
+                <span>Custom: {error.message}</span>
+                <button onClick={reset}>Custom Reset</button>
+              </div>
+            )}
+          >
+            <ProblemChild shouldThrow={true} />
+          </ErrorBoundary>
+        </MemoryRouter>
+      );
+    });
+
+    expect(container.textContent).toContain('Custom: Simulated tool rendering crash');
+    expect(container.textContent).toContain('Custom Reset');
+  });
+
+  it('allows recovery via Try Again reset button', () => {
+    function StatefulWrapper() {
+      const [hasError, setHasError] = useState(true);
+      return (
+        <MemoryRouter>
+          <ErrorBoundary toolTitle="Test Tool" onReset={() => setHasError(false)}>
+            <ProblemChild shouldThrow={hasError} />
+          </ErrorBoundary>
+        </MemoryRouter>
+      );
+    }
+
+    act(() => {
+      root.render(<StatefulWrapper />);
+    });
+
+    expect(container.textContent).toContain('Test Tool encountered an error');
+
+    const tryAgainBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Try Again')
+    );
+    expect(tryAgainBtn).toBeDefined();
+
+    act(() => {
+      tryAgainBtn?.click();
+    });
+
+    expect(container.textContent).toContain('Normal Tool Content');
+  });
+});

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,344 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { AlertTriangle, RotateCcw, ArrowLeft, Copy, Check, ShieldCheck } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  toolTitle?: string;
+  fallback?: (error: Error, reset: () => void) => ReactNode;
+  onReset?: () => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+  copied: boolean;
+  showDetails: boolean;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      copied: false,
+      showDetails: false,
+    };
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    this.setState({ errorInfo });
+    // Local debugging in dev console only — STRICTLY NO remote telemetry
+    if (process.env.NODE_ENV === 'development') {
+      console.error('[Toolglass ErrorBoundary Caught Error]:', error, errorInfo);
+    }
+  }
+
+  resetError = () => {
+    this.props.onReset?.();
+    this.setState({
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      copied: false,
+      showDetails: false,
+    });
+  };
+
+  handleCopyDebugInfo = async () => {
+    const { error, errorInfo } = this.state;
+    const { toolTitle } = this.props;
+
+    const debugReport = [
+      `### Toolglass Error Report`,
+      `- **Tool**: ${toolTitle || 'Application Shell'}`,
+      `- **Timestamp**: ${new Date().toISOString()}`,
+      `- **Error Message**: ${error?.message || 'Unknown error'}`,
+      `- **Error Name**: ${error?.name || 'Error'}`,
+      ``,
+      `#### Component Stack`,
+      '```text',
+      errorInfo?.componentStack?.trim() || 'No component stack available',
+      '```',
+      ``,
+      `*Note: Generated locally in Toolglass. 100% private, no remote tracking.*`,
+    ].join('\n');
+
+    try {
+      await navigator.clipboard.writeText(debugReport);
+      this.setState({ copied: true });
+      setTimeout(() => this.setState({ copied: false }), 2000);
+    } catch {
+      // Clipboard write fallback
+    }
+  };
+
+  render() {
+    const { hasError, error, errorInfo, copied, showDetails } = this.state;
+    const { children, toolTitle, fallback } = this.props;
+
+    if (!hasError) {
+      return children;
+    }
+
+    if (fallback && error) {
+      return fallback(error, this.resetError);
+    }
+
+    return (
+      <div
+        data-testid="error-boundary-card"
+        style={{
+          width: '100%',
+          maxWidth: 720,
+          margin: '40px auto',
+          padding: '36px 32px',
+          borderRadius: 'var(--radius)',
+          background: 'var(--glass-bg-strong)',
+          backdropFilter: 'blur(20px)',
+          WebkitBackdropFilter: 'blur(20px)',
+          border: '1px solid var(--glass-border)',
+          boxShadow: 'var(--glass-shadow)',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          textAlign: 'center',
+          position: 'relative',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Subtle glowing ambient backdrop */}
+        <div
+          aria-hidden
+          style={{
+            position: 'absolute',
+            top: -60,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: 260,
+            height: 180,
+            borderRadius: '50%',
+            background: 'radial-gradient(circle, rgba(239, 68, 68, 0.18) 0%, rgba(244, 114, 182, 0.1) 60%, transparent 80%)',
+            pointerEvents: 'none',
+            filter: 'blur(30px)',
+          }}
+        />
+
+        {/* Error icon badge */}
+        <div
+          style={{
+            width: 64,
+            height: 64,
+            borderRadius: 18,
+            background: 'linear-gradient(135deg, rgba(239, 68, 68, 0.15), rgba(244, 114, 182, 0.15))',
+            border: '1px solid rgba(239, 68, 68, 0.3)',
+            display: 'grid',
+            placeItems: 'center',
+            marginBottom: 20,
+            color: '#ef4444',
+            boxShadow: '0 8px 24px -4px rgba(239, 68, 68, 0.2)',
+          }}
+        >
+          <AlertTriangle size={30} strokeWidth={1.8} />
+        </div>
+
+        {/* Title */}
+        <h2
+          style={{
+            fontSize: 22,
+            fontWeight: 700,
+            letterSpacing: '-0.02em',
+            color: 'var(--ink)',
+            marginBottom: 8,
+          }}
+        >
+          {toolTitle ? `${toolTitle} encountered an error` : 'Something went wrong'}
+        </h2>
+
+        {/* Subtitle / friendly message */}
+        <p
+          style={{
+            fontSize: 14,
+            color: 'var(--ink-soft)',
+            maxWidth: 500,
+            lineHeight: 1.6,
+            marginBottom: 20,
+          }}
+        >
+          An unexpected issue occurred while rendering this tool. The rest of Toolglass remains fully functional.
+        </p>
+
+        {/* Error message pill */}
+        {error && (
+          <div
+            style={{
+              width: '100%',
+              maxWidth: 580,
+              padding: '12px 16px',
+              borderRadius: 'var(--radius-sm)',
+              background: 'rgba(239, 68, 68, 0.07)',
+              border: '1px solid rgba(239, 68, 68, 0.2)',
+              color: 'var(--ink)',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 13,
+              textAlign: 'left',
+              wordBreak: 'break-word',
+              marginBottom: 24,
+            }}
+          >
+            <span style={{ color: '#ef4444', fontWeight: 600, marginRight: 8 }}>Error:</span>
+            {error.message || 'Unknown runtime exception'}
+          </div>
+        )}
+
+        {/* Privacy assurance callout */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            fontSize: 12,
+            color: 'var(--ink-mute)',
+            background: 'var(--surface-nav-item)',
+            padding: '6px 12px',
+            borderRadius: 8,
+            border: '1px solid var(--glass-border)',
+            marginBottom: 24,
+          }}
+        >
+          <ShieldCheck size={14} color="var(--accent)" />
+          <span>100% Client-Side Privacy: No error logs or data were sent over the network.</span>
+        </div>
+
+        {/* Action buttons */}
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 12,
+            justifyContent: 'center',
+            alignItems: 'center',
+            marginBottom: 20,
+          }}
+        >
+          <button
+            onClick={this.resetError}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '10px 20px',
+              borderRadius: 10,
+              background: 'var(--accent)',
+              color: '#ffffff',
+              border: 'none',
+              fontSize: 14,
+              fontWeight: 600,
+              cursor: 'pointer',
+              boxShadow: '0 4px 14px rgba(139, 92, 246, 0.35)',
+              transition: 'transform 0.15s ease, opacity 0.15s ease',
+            }}
+            onMouseOver={(e) => { e.currentTarget.style.opacity = '0.92'; }}
+            onMouseOut={(e) => { e.currentTarget.style.opacity = '1'; }}
+          >
+            <RotateCcw size={15} strokeWidth={2.2} />
+            Try Again
+          </button>
+
+          <Link
+            to="/"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '10px 18px',
+              borderRadius: 10,
+              background: 'var(--surface-button-off)',
+              color: 'var(--ink)',
+              border: '1px solid var(--glass-border)',
+              fontSize: 14,
+              fontWeight: 600,
+              textDecoration: 'none',
+              transition: 'background 0.15s ease',
+            }}
+          >
+            <ArrowLeft size={15} strokeWidth={2.2} />
+            Return to Tools
+          </Link>
+
+          <button
+            onClick={this.handleCopyDebugInfo}
+            aria-label="Copy debug info"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '10px 14px',
+              borderRadius: 10,
+              background: 'var(--surface-button-off)',
+              color: 'var(--ink-soft)',
+              border: '1px solid var(--glass-border)',
+              fontSize: 13,
+              fontWeight: 500,
+              cursor: 'pointer',
+            }}
+          >
+            {copied ? <Check size={14} color="#10b981" /> : <Copy size={14} />}
+            {copied ? 'Copied' : 'Copy Debug Info'}
+          </button>
+        </div>
+
+        {/* Technical stack toggle */}
+        {errorInfo && (
+          <div style={{ width: '100%', maxWidth: 580, textAlign: 'left', marginTop: 8 }}>
+            <button
+              onClick={() => this.setState((prev) => ({ showDetails: !prev.showDetails }))}
+              style={{
+                background: 'transparent',
+                border: 'none',
+                color: 'var(--ink-mute)',
+                fontSize: 12,
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: '4px 0',
+                margin: '0 auto',
+              }}
+            >
+              <span>{showDetails ? 'Hide technical stack' : 'View technical stack (client-only)'}</span>
+            </button>
+
+            {showDetails && (
+              <pre
+                style={{
+                  marginTop: 10,
+                  padding: '12px 14px',
+                  borderRadius: 8,
+                  background: 'var(--kbd-bg)',
+                  border: '1px solid var(--kbd-border)',
+                  color: 'var(--ink-soft)',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 11,
+                  lineHeight: 1.5,
+                  overflowX: 'auto',
+                  maxHeight: 180,
+                  whiteSpace: 'pre-wrap',
+                }}
+              >
+                {errorInfo.componentStack?.trim() || 'No component stack recorded'}
+              </pre>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+}

--- a/src/pages/NotFound.test.tsx
+++ b/src/pages/NotFound.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { MemoryRouter } from 'react-router-dom';
+import { NotFound } from './NotFound';
+
+// Configure act environment for React 19
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('NotFound Page Component', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('renders general 404 page for unknown paths', () => {
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={['/random-unknown-path']}>
+          <NotFound />
+        </MemoryRouter>
+      );
+    });
+
+    expect(container.querySelector('[data-testid="not-found-page"]')).not.toBeNull();
+    expect(container.textContent).toContain('404');
+    expect(container.textContent).toContain('Page Not Found');
+    expect(container.textContent).toContain('/random-unknown-path');
+    expect(container.textContent).toContain('Explore All Tools');
+  });
+
+  it('renders tool-specific 404 when isToolNotFound is true', () => {
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={['/tools/invalid-tool-name']}>
+          <NotFound attemptedSlug="invalid-tool-name" isToolNotFound={true} />
+        </MemoryRouter>
+      );
+    });
+
+    expect(container.textContent).toContain('Tool Not Found:');
+    expect(container.textContent).toContain('invalid-tool-name');
+  });
+
+  it('suggests related tools when slug matches partially', () => {
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={['/tools/time']}>
+          <NotFound attemptedSlug="time" isToolNotFound={true} />
+        </MemoryRouter>
+      );
+    });
+
+    expect(container.textContent).toContain('Did you mean one of these tools?');
+    expect(container.textContent).toContain('Timestamp');
+  });
+
+  it('filters tools dynamically when typing in search input', () => {
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={['/unknown']}>
+          <NotFound />
+        </MemoryRouter>
+      );
+    });
+
+    const searchInput = container.querySelector('input[type="text"]') as HTMLInputElement;
+    expect(searchInput).not.toBeNull();
+
+    act(() => {
+      const nativeSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value'
+      )?.set;
+      nativeSetter?.call(searchInput, 'base64');
+      const inputEvent = new Event('input', { bubbles: true });
+      searchInput.dispatchEvent(inputEvent);
+      const changeEvent = new Event('change', { bubbles: true });
+      searchInput.dispatchEvent(changeEvent);
+    });
+
+    expect(container.textContent).toContain('Search Results for "base64"');
+  });
+});

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,377 @@
+import { useState, useMemo } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { Sparkles, ArrowLeft, Search, Compass, AlertCircle } from 'lucide-react';
+import { tools, type ToolMeta } from '../tools/registry';
+import { ToolCard } from '../components/ui/ToolCard';
+
+interface NotFoundProps {
+  attemptedSlug?: string;
+  isToolNotFound?: boolean;
+}
+
+// Lightweight similarity score for fuzzy suggestions
+function scoreToolMatch(query: string, tool: ToolMeta): number {
+  const q = query.toLowerCase().trim();
+  if (!q) return 0;
+
+  const slug = tool.slug.toLowerCase();
+  const title = tool.title.toLowerCase();
+  const shortDesc = tool.short.toLowerCase();
+
+  // Exact matches or prefix matches
+  if (slug === q) return 100;
+  if (slug.startsWith(q) || q.startsWith(slug)) return 80;
+  if (title.includes(q)) return 60;
+  if (slug.includes(q) || q.includes(slug)) return 50;
+  if (shortDesc.includes(q)) return 40;
+
+  // Character overlap score
+  const qChars = new Set(q.split(''));
+  let matchCount = 0;
+  for (const c of qChars) {
+    if (slug.includes(c)) matchCount++;
+  }
+  return (matchCount / Math.max(q.length, slug.length)) * 30;
+}
+
+export function NotFound({ attemptedSlug, isToolNotFound }: NotFoundProps) {
+  const location = useLocation();
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Determine attempted route or slug
+  const cleanPath = location.pathname || '';
+  const detectedSlug = attemptedSlug || (cleanPath.startsWith('/tools/') ? cleanPath.replace('/tools/', '') : '');
+  const isTool = isToolNotFound || Boolean(detectedSlug);
+
+  // Compute suggestions based on attempted slug or fallback to popular tools
+  const suggestedTools = useMemo(() => {
+    if (detectedSlug) {
+      const scored = tools
+        .map((t) => ({ tool: t, score: scoreToolMatch(detectedSlug, t) }))
+        .sort((a, b) => b.score - a.score);
+
+      const matches = scored.filter((item) => item.score > 20).map((item) => item.tool);
+      if (matches.length > 0) {
+        return matches.slice(0, 3);
+      }
+    }
+
+    // Default top utilities when no close match is found
+    const defaultSlugs = ['timestamp', 'jwt', 'password'];
+    return tools.filter((t) => defaultSlugs.includes(t.slug));
+  }, [detectedSlug]);
+
+  // Live filter if user types in the inline search box
+  const searchResults = useMemo(() => {
+    if (!searchQuery.trim()) return [];
+    const q = searchQuery.toLowerCase().trim();
+    return tools.filter(
+      (t) =>
+        t.title.toLowerCase().includes(q) ||
+        t.slug.toLowerCase().includes(q) ||
+        t.short.toLowerCase().includes(q)
+    );
+  }, [searchQuery]);
+
+  return (
+    <div
+      data-testid="not-found-page"
+      style={{
+        maxWidth: 960,
+        margin: '20px auto 48px',
+        padding: '0 16px',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        textAlign: 'center',
+      }}
+    >
+      {/* 404 Hero Card */}
+      <div
+        className="glass"
+        style={{
+          width: '100%',
+          padding: '48px 32px',
+          borderRadius: 'var(--radius)',
+          background: 'var(--glass-bg-strong)',
+          backdropFilter: 'blur(20px)',
+          WebkitBackdropFilter: 'blur(20px)',
+          border: '1px solid var(--glass-border)',
+          boxShadow: 'var(--glass-shadow)',
+          position: 'relative',
+          overflow: 'hidden',
+          marginBottom: 36,
+        }}
+      >
+        {/* Glowing atmospheric gradient */}
+        <div
+          aria-hidden
+          style={{
+            position: 'absolute',
+            top: -80,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: 320,
+            height: 220,
+            borderRadius: '50%',
+            background: 'radial-gradient(circle, rgba(139, 92, 246, 0.25) 0%, rgba(236, 72, 153, 0.15) 50%, transparent 80%)',
+            pointerEvents: 'none',
+            filter: 'blur(40px)',
+          }}
+        />
+
+        {/* 404 Visual Badge */}
+        <div
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '6px 14px',
+            borderRadius: 999,
+            background: 'var(--surface-nav-item)',
+            border: '1px solid var(--glass-border)',
+            fontSize: 13,
+            fontWeight: 700,
+            color: 'var(--accent)',
+            marginBottom: 20,
+            boxShadow: '0 2px 8px rgba(139, 92, 246, 0.12)',
+          }}
+        >
+          <Sparkles size={14} />
+          <span>404 · ERROR</span>
+        </div>
+
+        {/* Heading */}
+        <h1
+          style={{
+            fontSize: 'clamp(28px, 5vw, 42px)',
+            fontWeight: 800,
+            letterSpacing: '-0.03em',
+            color: 'var(--ink)',
+            marginBottom: 12,
+            lineHeight: 1.15,
+          }}
+        >
+          {isTool ? (
+            <>
+              Tool Not Found:{' '}
+              <span
+                style={{
+                  background: 'var(--grad)',
+                  WebkitBackgroundClip: 'text',
+                  WebkitTextFillColor: 'transparent',
+                }}
+              >
+                {detectedSlug || 'Unknown'}
+              </span>
+            </>
+          ) : (
+            'Page Not Found'
+          )}
+        </h1>
+
+        {/* Message */}
+        <p
+          style={{
+            fontSize: 16,
+            color: 'var(--ink-soft)',
+            maxWidth: 540,
+            margin: '0 auto 24px',
+            lineHeight: 1.6,
+          }}
+        >
+          {isTool
+            ? `The requested tool "${detectedSlug}" does not exist or may have been renamed.`
+            : `The path "${cleanPath}" does not exist in Toolglass.`}
+        </p>
+
+        {/* Inline Search Bar */}
+        <div
+          style={{
+            maxWidth: 480,
+            margin: '0 auto 28px',
+            position: 'relative',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+              padding: '10px 16px',
+              borderRadius: 'var(--radius-sm)',
+              background: 'var(--surface-input)',
+              border: '1px solid var(--glass-border)',
+              boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.04)',
+            }}
+          >
+            <Search size={16} color="var(--ink-mute)" />
+            <input
+              type="text"
+              placeholder="Search tools directly (e.g. base64, jwt, cron)..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              aria-label="Search tools directly"
+              style={{
+                width: '100%',
+                background: 'transparent',
+                border: 'none',
+                outline: 'none',
+                fontSize: 14,
+                color: 'var(--ink)',
+                fontFamily: 'var(--font-sans)',
+              }}
+            />
+            {searchQuery && (
+              <button
+                onClick={() => setSearchQuery('')}
+                style={{
+                  background: 'transparent',
+                  border: 'none',
+                  color: 'var(--ink-mute)',
+                  cursor: 'pointer',
+                  fontSize: 13,
+                  padding: 2,
+                }}
+              >
+                ✕
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 12,
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          <Link
+            to="/"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '12px 22px',
+              borderRadius: 12,
+              background: 'var(--accent)',
+              color: '#ffffff',
+              fontSize: 14,
+              fontWeight: 600,
+              textDecoration: 'none',
+              boxShadow: '0 4px 16px rgba(139, 92, 246, 0.35)',
+              transition: 'transform 0.15s ease, opacity 0.15s ease',
+            }}
+          >
+            <ArrowLeft size={16} strokeWidth={2.2} />
+            Explore All Tools
+          </Link>
+        </div>
+      </div>
+
+      {/* Search Results (if user is actively typing) */}
+      {searchQuery.trim() && (
+        <div style={{ width: '100%', textAlign: 'left', marginBottom: 32 }}>
+          <h2
+            style={{
+              fontSize: 18,
+              fontWeight: 700,
+              color: 'var(--ink)',
+              marginBottom: 16,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+            }}
+          >
+            <Search size={18} color="var(--accent)" />
+            Search Results for "{searchQuery}" ({searchResults.length})
+          </h2>
+
+          {searchResults.length > 0 ? (
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+                gap: 16,
+              }}
+            >
+              {searchResults.map((tool) => (
+                <ToolCard key={tool.slug} tool={tool} />
+              ))}
+            </div>
+          ) : (
+            <div
+              className="glass"
+              style={{
+                padding: 24,
+                borderRadius: 'var(--radius-sm)',
+                textAlign: 'center',
+                color: 'var(--ink-soft)',
+                fontSize: 14,
+              }}
+            >
+              <AlertCircle size={24} color="var(--ink-mute)" style={{ margin: '0 auto 8px' }} />
+              No tools matching "{searchQuery}". Try browsing all tools on the home page.
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Suggested Tools Section (Shown when not actively searching) */}
+      {!searchQuery.trim() && suggestedTools.length > 0 && (
+        <div style={{ width: '100%', textAlign: 'left' }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              marginBottom: 16,
+            }}
+          >
+            <h2
+              style={{
+                fontSize: 18,
+                fontWeight: 700,
+                color: 'var(--ink)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+              }}
+            >
+              <Compass size={18} color="var(--accent)" />
+              {detectedSlug ? 'Did you mean one of these tools?' : 'Popular Utilities'}
+            </h2>
+            <Link
+              to="/"
+              style={{
+                fontSize: 13,
+                fontWeight: 600,
+                color: 'var(--accent)',
+                textDecoration: 'none',
+              }}
+            >
+              View all 17 tools →
+            </Link>
+          </div>
+
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+              gap: 16,
+            }}
+          >
+            {suggestedTools.map((tool) => (
+              <ToolCard key={tool.slug} tool={tool} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+export default NotFound;

--- a/src/pages/ToolPage.tsx
+++ b/src/pages/ToolPage.tsx
@@ -1,8 +1,10 @@
 import { AnimatePresence, motion } from 'framer-motion';
 import { Suspense, useEffect, useState } from 'react';
-import { Navigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { toolBySlug } from '../tools/registry';
 import { useRecentTools } from '../hooks/useRecentTools';
+import { ErrorBoundary } from '../components/ErrorBoundary';
+import { NotFound } from './NotFound';
 
 /* ── Cycling phrases shown while the tool chunk loads ────────────── */
 const PHRASES = [
@@ -137,11 +139,16 @@ export function ToolPage() {
     }
   }, [tool, addRecent]);
 
-  if (!tool) return <Navigate to="/" replace />;
+  if (!tool) {
+    return <NotFound attemptedSlug={slug} isToolNotFound={true} />;
+  }
+
   const { Component } = tool;
   return (
-    <Suspense fallback={<Loader />}>
-      <Component />
-    </Suspense>
+    <ErrorBoundary toolTitle={tool.title}>
+      <Suspense fallback={<Loader />}>
+        <Component />
+      </Suspense>
+    </ErrorBoundary>
   );
 }


### PR DESCRIPTION
Resolves #56 and #65.

### Summary of Changes

1. **Reusable Glassmorphic `ErrorBoundary` (`src/components/ErrorBoundary.tsx`)**:
   - Class-based React error boundary with `componentDidCatch` and `static getDerivedStateFromError`.
   - **100% Client-Side Privacy**: Zero remote telemetry, zero external logging.
   - User-friendly error card matching Toolglass's glassmorphic aesthetics.
   - Expandable technical details (closed by default) + "Copy Debug Info" button for optional manual issue reporting.
   - "Try Again" button that resets component state without page refresh.
   - Integrated in `ToolPage.tsx` (wrapping tool components) and in `App.tsx` (protecting the app shell).

2. **Custom 404 & Tool-Not-Found Page (`src/pages/NotFound.tsx`)**:
   - Beautiful glassmorphic 404 page with ✦ visual identity.
   - Replaced silent redirect with explicit feedback for invalid paths and tool slugs.
   - **Fuzzy Tool Suggestions**: Computes string similarity against registered tools to suggest matches (e.g. `/#/tools/time-conv` -> suggests Timestamp).
   - **Embedded Search**: Live inline search box on the 404 page.
   - "Explore All Tools" navigation button.

3. **Automated Unit & E2E Testing**:
   - `src/components/ErrorBoundary.test.tsx`: 4 Vitest unit tests verifying normal rendering, error catching, fallback UI, and recovery via Try Again.
   - `src/pages/NotFound.test.tsx`: 4 Vitest unit tests verifying generic 404, tool-specific 404, fuzzy suggestions, and live search filtering.
   - All 28 unit tests passing cleanly.
   - Headless Chromium regression test passed with 0 console errors.

Closes #56
Closes #65
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajithakdev/toolglass/pull/90" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->